### PR TITLE
Wait for update before setting active slide

### DIFF
--- a/src/components/player-artwork.ts
+++ b/src/components/player-artwork.ts
@@ -201,7 +201,7 @@ export class MassPlayerArtwork extends LitElement {
     `
   }
   protected shouldUpdate(_changedProperties: PropertyValues): boolean {
-    return super.shouldUpdate(_changedProperties)
+    return _changedProperties.size > 0
   }
   connectedCallback(): void {
     if (this.hasUpdated){


### PR DESCRIPTION
Ensures that change doesn't occur in the middle of an update and gets lost. 