### PR TITLE
Rename config options for hidden elements. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,31 +148,27 @@ expressive: true
 expressive_theme: expressive
 panel: false
 default_section: music_player
+sync_player_across_dashboard: false
+download_local: false
 entities:
   - entity_id: <MEDIA_PLAYER_ENTITY>
     volume_entity_id: <MEDIA_PLAYER_ENTITY>
     max_volume: 100
     name: <MEDIA_PLAYER_ENTITY_NAME>
     inactive_when_idle: true
-    hide:
-      player:
-        favorite: false
-        mute: false
-        player_selector: false
-        power: false
-        repeat: false
-        shuffle: false
-        volume: false
 queue:
   enabled: true
   hide:
+    header: false
+    header_title: false
+    clear_queue_button: false
+    artist_names: false
+    album_covers: false
     action_buttons: false
     move_down_button: false
     move_next_button: false
     move_up_button: false
     remove_button: false
-    album_covers: false
-    artist_names: false
   limit_before: 5
   limit_after: 100
   show_album_covers: true
@@ -180,43 +176,71 @@ queue:
 player:
   enabled: true
   hide:
-    favorite: false
-    mute: false
+    header: false
+    header_title: false
     player_selector: false
+    group_selector: false
+    player_name: false
+    track_title: false
+    track_artist: false
+    track_progress_time: false
+    track_progress_bar: false
     power: false
     repeat: false
     shuffle: false
+    favorite: false
     volume: false
-    group_volume: false
+    mute: false
   layout:
     controls_layout: compact
+    hide_labels: false
+    artwork_size: large
     icons:
       shuffle:
         size: small
         box_shadow: false
+        label: true
       previous:
         size: small
         box_shadow: false
+        label: true
       play_pause:
         size: large
         box_shadow: true
+        label: true
       next:
         size: small
         box_shadow: false
+        label: true
       repeat:
         size: small
         box_shadow: false
+        label: true
+      power:
+        size: small
+        box_shadow: false
+        label: true
+      favorite:
+        size: small
+        box_shadow: false
+        label: true
 players:
   enabled: true
   hide:
+    header: false
+    header_title: false
     action_buttons: false
     join_button: false
     transfer_button: false
 media_browser:
   enabled: true
-  hidden:
+  playlists_allow_removing_tracks: false
+  hide:
+    header: false
+    header_title: false
     back_button: false
-    search: false
+    filter_button: false
+    search_button: false
     titles: false
     enqueue_menu: false
     add_to_queue_button: false
@@ -226,9 +250,7 @@ media_browser:
     play_now_clear_queue_button: false
   recents:
     enabled: true
-  recommendations:
-    enabled: true
-  favorites:
+    show_collection_view: true
     albums:
       enabled: true
       limit: 25
@@ -257,7 +279,40 @@ media_browser:
       enabled: true
       limit: 25
       favorites_only: true
-playlists_allow_removing_tracks: false
+  recommendations:
+    enabled: true
+    show_collection_view: true
+  favorites:
+    enabled: true
+    show_collection_view: true
+    albums:
+      enabled: true
+      limit: 25
+      favorites_only: true
+    artists:
+      enabled: true
+      limit: 25
+      favorites_only: true
+    audiobooks:
+      enabled: true
+      limit: 25
+      favorites_only: true
+    playlists:
+      enabled: true
+      limit: 25
+      favorites_only: true
+    podcasts:
+      enabled: true
+      limit: 25
+      favorites_only: true
+    radios:
+      enabled: true
+      limit: 25
+      favorites_only: true
+    tracks:
+      enabled: true
+      limit: 25
+      favorites_only: true
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ Multiple elements on the media browser tab can be hidden. By default, all elemen
 | header_title                 | bool  | No       | false       | Hides the section titles in the header     |
 | back_button                  | bool  | No       | false       | Hides the back button                      |
 | filter_button                | bool  | No       | false       | Hides the filter button                    |
-| search                       | bool  | No       | false       | Hides the search button                    |
+| search_button                | bool  | No       | false       | Hides the search button                    |
 | titles                       | bool  | No       | false       | Hides titles for each section/item         |
 | enqueue_menu                 | bool  | No       | false       | Hides the enqueue menu                     |
 | add_to_queue_button          | bool  | No       | false       | Hides the "Add to Queue" button            |

--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ player:
     track_artist: false
     track_progress_time: false
     track_progress_bar: false
-    power: false
-    repeat: false
-    shuffle: false
-    favorite: false
+    power_button: false
+    repeat_button: false
+    shuffle_button: false
+    favorite_button: false
     volume: false
-    mute: false
+    mute_button: false
   layout:
     controls_layout: compact
     hide_labels: false
@@ -336,12 +336,12 @@ entities:
     inactive_when_idle: true
     hide:
       player:
-        favorite: true
-        mute: true
+        favorite_button: true
+        mute_button: true
         player_selector: true
-        power: true
-        repeat: true
-        shuffle: true
+        power_button: true
+        repeat_button: true
+        shuffle_button: true
         volume: true
   - entity_id: media_player.living_room_player_music_assistant
     volume_entity_id: media_player.living_room_tv
@@ -350,8 +350,8 @@ entities:
     max_volume: 50
     hide:
       player:
-        mute: true
-        power: true
+        mute_button: true
+        power_button: true
         volume: true
       queue:
         move_up_button: true
@@ -363,8 +363,8 @@ entities:
     name: Basement
     hide:
       player:
-        mute: true
-        power: true
+        mute_button: true
+        power_button: true
 queue:
   enabled: true
   limit_before: 10
@@ -440,7 +440,7 @@ media_browser:
     providers:
       - plex
       - tidal
-playlists_allow_removing_tracks: false
+  playlists_allow_removing_tracks: false
 ```
 
 </details>
@@ -534,12 +534,12 @@ Multiple elements on the Music Player tab can be hidden. By default, all element
 | track_artist        | bool  | No       | false       | Hides the track artist                       |
 | track_progress_time | bool  | No       | false       | Hides the track progress time                |
 | track_progress_bar  | bool  | No       | false       | Hides the track progress bar                 |
-| power               | bool  | No       | false       | Hides the power button                       |
-| repeat              | bool  | No       | false       | Hides the repeat button                      |
-| shuffle             | bool  | No       | false       | Hides the shuffle button                     |
-| favorite            | bool  | No       | false       | Hides the favorite button                    |
+| power_button        | bool  | No       | false       | Hides the power button                       |
+| repeat_button       | bool  | No       | false       | Hides the repeat button                      |
+| shuffle_button      | bool  | No       | false       | Hides the shuffle button                     |
+| favorite_button     | bool  | No       | false       | Hides the favorite button                    |
 | volume              | bool  | No       | false       | Hides the volume button                      |
-| mute                | bool  | No       | false       | Hides the mute button                        |
+| mute_button         | bool  | No       | false       | Hides the mute button                        |
 
 #### Music Player Layout Config
 The layout of the control buttons can be adjusted to your liking. Use the full default configuration below as an example.

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Multiple elements on the Music Player tab can be hidden. By default, all element
 | header              | bool  | No       | false       | Hides the entire header                      |
 | header_title        | bool  | No       | false       | Hides the "Media Player" title in the header |
 | player_selector     | bool  | No       | false       | Hides the player selector button             |
-| group_volume        | bool  | No       | false       | Hides the grouped player volume menu         |
+| group_selector      | bool  | No       | false       | Hides the grouped player volume menu         |
 | player_name         | bool  | No       | false       | Hides the player name                        |
 | track_title         | bool  | No       | false       | Hides the track title                        |
 | track_artist        | bool  | No       | false       | Hides the track artist                       |

--- a/src/components/player-controls/player-controls-expressive.ts
+++ b/src/components/player-controls/player-controls-expressive.ts
@@ -73,7 +73,7 @@ class MassPlayerControlsExpressive extends MassPlayerControlsBase {
     `;
   }
   protected renderPower(): TemplateResult {
-    if (this.hiddenElements.power) {
+    if (this.hiddenElements.power_button) {
       return html``;
     }
     const label = this.renderLabel(
@@ -99,7 +99,7 @@ class MassPlayerControlsExpressive extends MassPlayerControlsBase {
     `;
   }
   protected renderShuffle(): TemplateResult {
-    if (this.hiddenElements.shuffle) {
+    if (this.hiddenElements.shuffle_button) {
       return html``;
     }
     const shuffle = this.shuffle;
@@ -132,7 +132,7 @@ class MassPlayerControlsExpressive extends MassPlayerControlsBase {
     `;
   }
   protected renderRepeat(): TemplateResult {
-    if (this.hiddenElements.repeat) {
+    if (this.hiddenElements.repeat_button) {
       return html``;
     }
     const repeat = this.repeat;
@@ -167,7 +167,7 @@ class MassPlayerControlsExpressive extends MassPlayerControlsBase {
     `;
   }
   protected renderFavorite(): TemplateResult {
-    if (this.hiddenElements.favorite) {
+    if (this.hiddenElements.favorite_button) {
       return html``;
     }
     const favorite = this.favorite;
@@ -209,7 +209,11 @@ class MassPlayerControlsExpressive extends MassPlayerControlsBase {
   }
   protected renderLowerControls(): TemplateResult {
     const h = this.hiddenElements;
-    const all_hidden = h.power && h.shuffle && h.repeat && h.favorite;
+    const all_hidden =
+      h.power_button &&
+      h.shuffle_button &&
+      h.repeat_button &&
+      h.favorite_button;
     if (all_hidden) {
       return html``;
     }

--- a/src/components/player-controls/player-controls.ts
+++ b/src/components/player-controls/player-controls.ts
@@ -11,7 +11,7 @@ import styles from "./player-controls-styles";
 
 class MassPlayerControls extends MassPlayerControlsBase {
   protected renderShuffle(): TemplateResult {
-    if (this.hiddenElements.shuffle) {
+    if (this.hiddenElements.shuffle_button) {
       return html``;
     }
     const icon_style = this.layoutConfig.icons.shuffle;
@@ -172,7 +172,7 @@ class MassPlayerControls extends MassPlayerControlsBase {
     `;
   }
   protected renderRepeat(): TemplateResult {
-    if (this.hiddenElements.repeat) {
+    if (this.hiddenElements.repeat_button) {
       return html``;
     }
     const icon = getRepeatIcon(this._playerData.repeat, this.Icons);

--- a/src/components/volume-row/volume-row.ts
+++ b/src/components/volume-row/volume-row.ts
@@ -108,7 +108,7 @@ class VolumeRow extends LitElement {
       : this.actions.actionAddFavorite());
   };
   protected renderPower(): TemplateResult {
-    if (this.hide.power || this.useExpressive) {
+    if (this.hide.power_button || this.useExpressive) {
       return html``;
     }
     return html`
@@ -126,7 +126,7 @@ class VolumeRow extends LitElement {
     `;
   }
   protected renderMute(): TemplateResult {
-    if (this.hide.mute) {
+    if (this.hide.mute_button) {
       return html``;
     }
     return html`
@@ -149,7 +149,7 @@ class VolumeRow extends LitElement {
     `;
   }
   protected renderFavorite(): TemplateResult {
-    if (this.hide.favorite || this.useExpressive) {
+    if (this.hide.favorite_button || this.useExpressive) {
       return html``;
     }
     return html`

--- a/src/config/media-browser.ts
+++ b/src/config/media-browser.ts
@@ -60,7 +60,7 @@ export interface MediaBrowserHiddenElementsConfig extends BaseHiddenElementsConf
   header_title: boolean;
   back_button: boolean;
   filter_button: boolean;
-  search: boolean;
+  search_button: boolean;
   titles: boolean;
   enqueue_menu: boolean;
   add_to_queue_button: boolean;
@@ -101,7 +101,7 @@ export const DEFAULT_MEDIA_BROWSER_HIDDEN_ELEMENTS_CONFIG: MediaBrowserHiddenEle
   {
     back_button: false,
     filter_button: false,
-    search: false,
+    search_button: false,
     titles: false,
     enqueue_menu: false,
     add_to_queue_button: false,

--- a/src/config/player.ts
+++ b/src/config/player.ts
@@ -8,10 +8,10 @@ export interface PlayerConfig {
 }
 
 export interface PlayerControlsHiddenElementsConfig extends BaseHiddenElementsConfig {
-  power: boolean;
-  repeat: boolean;
-  shuffle: boolean;
-  favorite: boolean;
+  power_button: boolean;
+  repeat_button: boolean;
+  shuffle_button: boolean;
+  favorite_button: boolean;
 }
 export interface PlayerHiddenElementsConfig extends BaseHiddenElementsConfig {
   header: boolean;
@@ -23,12 +23,12 @@ export interface PlayerHiddenElementsConfig extends BaseHiddenElementsConfig {
   track_artist: boolean;
   track_progress_time: boolean;
   track_progress_bar: boolean;
-  power: boolean;
-  repeat: boolean;
-  shuffle: boolean;
-  favorite: boolean;
+  power_button: boolean;
+  repeat_button: boolean;
+  shuffle_button: boolean;
+  favorite_button: boolean;
   volume: boolean;
-  mute: boolean;
+  mute_button: boolean;
 }
 
 export interface PlayerLayoutConfig {
@@ -68,12 +68,12 @@ export enum PlayerIconSize {
 
 export const DEFAULT_PLAYER_HIDDEN_ELEMENTS_CONFIG: PlayerHiddenElementsConfig =
   {
-    favorite: false,
-    mute: false,
+    favorite_button: false,
+    mute_button: false,
     player_selector: false,
-    power: false,
-    repeat: false,
-    shuffle: false,
+    power_button: false,
+    repeat_button: false,
+    shuffle_button: false,
     volume: false,
     group_selector: false,
     player_name: false,

--- a/src/config/player.ts
+++ b/src/config/player.ts
@@ -17,7 +17,7 @@ export interface PlayerHiddenElementsConfig extends BaseHiddenElementsConfig {
   header: boolean;
   header_title: boolean;
   player_selector: boolean;
-  group_volume: boolean;
+  group_selector: boolean;
   player_name: boolean;
   track_title: boolean;
   track_artist: boolean;
@@ -75,7 +75,7 @@ export const DEFAULT_PLAYER_HIDDEN_ELEMENTS_CONFIG: PlayerHiddenElementsConfig =
     repeat: false,
     shuffle: false,
     volume: false,
-    group_volume: false,
+    group_selector: false,
     player_name: false,
     track_artist: false,
     track_progress_bar: false,
@@ -141,7 +141,7 @@ const PLAYER_HIDDEN_ITEMS = [
   "repeat",
   "shuffle",
   "volume",
-  "group_volume",
+  "group_selector",
 ];
 
 function iconConfigForm(icon_name: string) {

--- a/src/sections/media-browser.ts
+++ b/src/sections/media-browser.ts
@@ -601,7 +601,7 @@ export class MediaBrowser extends LitElement {
     `;
   }
   protected renderSearchButton(): TemplateResult {
-    const hide = this.hiddenElements.search;
+    const hide = this.hiddenElements.search_button;
     if (hide) {
       return html``;
     }

--- a/src/sections/music-player.ts
+++ b/src/sections/music-player.ts
@@ -402,7 +402,7 @@ class MusicPlayerCard extends LitElement {
     return this.wrapTitleMarquee();
   }
   protected renderGrouped(): TemplateResult {
-    const hide = this.hiddenElements.group_volume;
+    const hide = this.hiddenElements.group_selector;
     if (this.groupedPlayers && this.groupedPlayers.length > 1 && !hide) {
       return html`
         <mpc-grouped-player-menu slot="end"></mpc-grouped-player-menu>


### PR DESCRIPTION
`player.hide.group_volume` -> `player.hide.group_selector`
`player.hide.power` -> `player.hide.power_button`
`player.hide.repeat` -> `player.hide.repeat_button`
`player.hide.shuffle` -> `player.hide.shuffle_button`
`player.hide.favorite` -> `player.hide.favorite_button`
`player.hide.mute` -> `player.hide.mute_button`
`media_browser.hide.search` -> `media_browser.hide.search_button`
