### PR TITLE
[codex] Fix queue rendering without virtualizer

### DIFF
--- a/src/sections/player-queue.ts
+++ b/src/sections/player-queue.ts
@@ -47,7 +47,7 @@ import { QueueController } from "../controller/queue";
 import { jsonMatch } from "../utils/utility";
 import { getTranslation } from "../utils/translations";
 import { Icons } from "../const/icons";
-import { LitVirtualizer, WaAnimation } from "../const/elements";
+import { WaAnimation } from "../const/elements";
 
 @customElement("mpc-queue-card")
 export class QueueCard extends LitElement {
@@ -70,7 +70,6 @@ export class QueueCard extends LitElement {
 
   @queryAll("#animation") _animations?: WaAnimation[];
   @query(".media-active") _activeElement!: HTMLElement;
-  @query("lit-virtualizer") virtualizerElement!: LitVirtualizer;
   @query(".list") _items!: HTMLElement;
 
   private _firstLoaded = false;
@@ -194,9 +193,7 @@ export class QueueCard extends LitElement {
     if (!activeIdx && activeIdx != 0) {
       return;
     }
-    this.virtualizerElement
-      .element(activeIdx)
-      .scrollIntoView({ block: "start", behavior: "auto" });
+    this._activeElement?.scrollIntoView({ block: "start", behavior: "auto" });
   }
   private onQueueItemSelected = async (queue_item_id: string) => {
     if (!this.queueController) {
@@ -261,15 +258,7 @@ export class QueueCard extends LitElement {
     `;
   }
   private renderQueueItems(): TemplateResult {
-    return html`
-      <lit-virtualizer
-        scroller
-        .items=${this.queue ?? []}
-        .renderItem=${(item: QueueItem) => {
-          return this.renderQueueItem(item);
-        }}
-      ></lit-virtualizer>
-    `;
+    return html`${this.queue?.map((item) => this.renderQueueItem(item))}`;
   }
   protected renderClearQueueButton(): TemplateResult {
     const expressive = this.activePlayerController.useExpressive;


### PR DESCRIPTION
## Summary

Fix the queue tab rendering by removing the `lit-virtualizer` path from `player-queue` and rendering queue rows directly.

## Root cause

The backend queue data was valid, but the queue section's virtualized renderer failed to display non-empty queues in the player card. Direct row rendering worked with the same queue items, which narrowed the failure to the queue card render path rather than `mass_queue` response shape or local media metadata.

## What changed

- remove the `lit-virtualizer` import and query from `player-queue`
- render `mpc-queue-media-row` items directly
- scroll to the active row via the existing `.media-active` element instead of virtualizer APIs

## Validation

- confirmed the queue controller had items for the affected player
- confirmed `mass_queue.get_queue_items` returned valid data for the same queue
- confirmed individual queue rows rendered correctly with the existing item shape
- verified the queue became visible after switching the queue section away from the virtualized render path

## Notes

This is intentionally narrow and does not try to change queue item shape handling or media metadata assumptions.
