### PR TITLE
feat: add artwork_size setting to media browser and collection views

### DIFF
--- a/src/components/browser-collection-view/browser-view-base.ts
+++ b/src/components/browser-collection-view/browser-view-base.ts
@@ -40,6 +40,7 @@ import { cache } from "lit/directives/cache.js";
 import "../marquee-text/marquee-text";
 import { PodcastEpisode } from "mass-queue-types/packages/mass_queue/types/media-items";
 import "./browser-collection-track-row";
+import { ArtworkSize } from "../../config/player";
 
 export class BrowserViewBase extends LitElement {
   protected _collectionData?: mediaCardCollectionType | undefined;
@@ -362,12 +363,27 @@ export class BrowserViewBase extends LitElement {
       </div>
     `;
   }
+  private _collectionImageStyles(): string {
+    const artworkSize = this.browserConfig?.artwork_size ?? ArtworkSize.MEDIUM;
+    const heights: Record<ArtworkSize, string> = {
+      [ArtworkSize.SMALL]: "6em",
+      [ArtworkSize.MEDIUM]: "10em",
+      [ArtworkSize.LARGE]: "14em",
+    };
+    const collapsedHeights: Record<ArtworkSize, string> = {
+      [ArtworkSize.SMALL]: "3.6em",
+      [ArtworkSize.MEDIUM]: "6em",
+      [ArtworkSize.LARGE]: "8.4em",
+    };
+    return `--browser-collection-image-height: ${heights[artworkSize]}; --browser-collection-image-collapsed-height: ${collapsedHeights[artworkSize]};`;
+  }
+
   protected render(): TemplateResult {
     const expressiveClass = this.useExpressive ? `expressive` : ``;
     const vibrantClass = this.useVibrant ? `vibrant` : ``;
     const scrollClass = this.tracks?.length ? `` : `no-scroll`;
     return html`
-      <div id="container" class="${expressiveClass} ${vibrantClass}">
+      <div id="container" class="${expressiveClass} ${vibrantClass}" style="${this._collectionImageStyles()}">
         <div id="header">
           ${this.renderHeader()}
         </div>

--- a/src/components/browser-collection-view/browser-view-shared-styles.ts
+++ b/src/components/browser-collection-view/browser-view-shared-styles.ts
@@ -67,9 +67,9 @@ export default css`
   }
   #collection-image {
     display: flex;
-    height: 10em;
+    height: var(--browser-collection-image-height, 10em);
     aspect-ratio: 1;
-    --collection-image-div-collapsed-height: 6em;
+    --collection-image-div-collapsed-height: var(--browser-collection-image-collapsed-height, 6em);
     margin-left: 1em;
     margin-top: 1em;
   }

--- a/src/components/media-browser-cards/media-browser-cards.ts
+++ b/src/components/media-browser-cards/media-browser-cards.ts
@@ -20,6 +20,7 @@ import { ExtendedHass, mediaCardData, MediaCardItem } from "../../const/types";
 
 import styles from "./media-browser-cards-styles";
 import { MediaBrowserConfig } from "../../config/media-browser";
+import { ArtworkSize } from "../../config/player";
 import { jsonMatch } from "../../utils/utility";
 import { EnqueueOptions } from "../../const/enums";
 
@@ -99,6 +100,14 @@ export class MediaBrowserCards extends LitElement {
       `;
       return;
     }
+    const artworkSize = this.browserConfig?.artwork_size ?? ArtworkSize.MEDIUM;
+    const artworkSizeMaxWidths: Record<ArtworkSize, string> = {
+      [ArtworkSize.SMALL]: "6em",
+      [ArtworkSize.MEDIUM]: "10em",
+      [ArtworkSize.LARGE]: "14em",
+    };
+    const maxWidthCap = artworkSizeMaxWidths[artworkSize];
+
     const result = this.items?.map((item) => {
       const queueable = [
         "service",
@@ -109,10 +118,11 @@ export class MediaBrowserCards extends LitElement {
       ].includes(item.data.type)
         ? literal`queueable`
         : literal``;
-      const width = (1 / (this.browserConfig?.columns ?? 1)) * 100 - 2;
+      const baseWidth = (1 / (this.browserConfig?.columns ?? 1)) * 100 - 2;
+      const maxWidth = `min(${baseWidth.toString()}%, ${maxWidthCap})`;
       return html`
         <mpc-browser-media-card
-          style="max-width: ${width.toString()}%"
+          style="max-width: ${maxWidth}"
           .config=${item}
           .onSelectAction=${this.onItemSelected}
           .onEnqueueAction=${this.onEnqueue}

--- a/src/config/media-browser.ts
+++ b/src/config/media-browser.ts
@@ -2,6 +2,7 @@ import { mdiCreation, mdiHeart, mdiHistory } from "@mdi/js";
 
 import { BaseHiddenElementsConfig, Config } from "./config";
 import { hiddenElementsConfigItem } from "../utils/config";
+import { ArtworkSize } from "./player";
 
 type BrowserSection = "favorites" | "recents" | "recommendations";
 
@@ -13,6 +14,7 @@ export interface MediaBrowserConfig {
   sections: customSection[];
   hide: MediaBrowserHiddenElementsConfig;
   columns: number;
+  artwork_size: ArtworkSize;
   playlists_allow_removing_tracks: boolean;
   default_enqueue_option: EnqueueConfigOptions;
   default_section: BrowserSection;
@@ -136,6 +138,7 @@ export const DEFAULT_MEDIA_BROWSER_CONFIG: MediaBrowserConfig = {
   sections: DEFAULT_CUSTOM_SECTION_CONFIG,
   hide: DEFAULT_MEDIA_BROWSER_HIDDEN_ELEMENTS_CONFIG,
   columns: 2,
+  artwork_size: ArtworkSize.MEDIUM,
   playlists_allow_removing_tracks: false,
   default_enqueue_option: "play_now",
   default_section: "favorites",
@@ -196,6 +199,40 @@ function recommendationsConfigForm() {
     ],
   };
 }
+function artworkSizeConfigForm() {
+  return {
+    name: "artwork_size",
+    selector: {
+      select: {
+        multiple: false,
+        custom_value: true,
+        mode: "dropdown",
+        options: [
+          {
+            label: "Small (6em)",
+            value: "small",
+            description: "6em, compact thumbnails",
+          },
+          {
+            label: "Medium (10em)",
+            value: "medium",
+            description: "10em, balanced",
+          },
+          {
+            label: "Large (14em)",
+            value: "large",
+            description: "14em, prominent",
+          },
+        ],
+      },
+      default: "medium",
+      description: {
+        suffix: "Set the size of artwork in the browser and collection views",
+      },
+    },
+  };
+}
+
 function defaultSectionConfigForm() {
   return {
     name: "default_section",
@@ -270,6 +307,7 @@ export function mediaBrowserConfigForm() {
   return [
     { name: "enabled", selector: { boolean: {} }, default: true },
     { name: "columns", selector: { number: { min: 1, max: 10, mode: "box" } } },
+    artworkSizeConfigForm(),
     defaultSectionConfigForm(),
     defaultEnqueueOptionConfigForm(),
     {


### PR DESCRIPTION
## Summary

Extends the existing `artwork_size` config option (previously only available in the **Player** section) to the **Media Browser** section, giving users control over album art dimensions when browsing and searching.

### What changed

- **`src/config/media-browser.ts`** — adds `artwork_size: ArtworkSize` to `MediaBrowserConfig`, defaults to `medium` (10em), and registers the dropdown in the settings form
- **`src/components/media-browser-cards/media-browser-cards.ts`** — applies `min(<column-based-width>%, <size-cap>)` to each card's `max-width`, so the artwork size cap works alongside the existing `columns` setting in favorites, recents, recommendations, and search results
- **`src/components/browser-collection-view/browser-view-base.ts`** — injects `--browser-collection-image-height` and `--browser-collection-image-collapsed-height` CSS variables onto the container based on the selected size; the collapse animation scales proportionally
- **`src/components/browser-collection-view/browser-view-shared-styles.ts`** — switches `#collection-image` from a hardcoded `10em` height to the new CSS variables (with `10em`/`6em` as fallbacks)

### Sizes

| Option | Browser cards cap | Collection image |
|--------|------------------|-----------------|
| Small  | 6em              | 6em             |
| Medium | 10em (default)   | 10em            |
| Large  | 14em             | 14em            |

The `medium` default matches the existing hardcoded collection image height, so existing configs see no visual change.