### PR TITLE
Fix expressive scheme not applying over HTTP connections

### DIFF
--- a/src/utils/expressive.ts
+++ b/src/utils/expressive.ts
@@ -113,7 +113,7 @@ export async function generateImageElement(
   fallbacks: string[] = [],
 ): Promise<HTMLImageElement | false> {
   return (await tryPrefetchImageWithFallbacks(img, fallbacks, hass, true)) as
-    HTMLImageElement 
+    | HTMLImageElement 
     | false;
 }
 

--- a/src/utils/expressive.ts
+++ b/src/utils/expressive.ts
@@ -113,7 +113,8 @@ export async function generateImageElement(
   fallbacks: string[] = [],
 ): Promise<HTMLImageElement | false> {
   return (await tryPrefetchImageWithFallbacks(img, fallbacks, hass, true)) as
-    HTMLImageElement | false;
+    HTMLImageElement 
+    | false;
 }
 
 export async function generateExpressiveSourceColorFromImage(

--- a/src/utils/expressive.ts
+++ b/src/utils/expressive.ts
@@ -17,6 +17,7 @@ import {
 import { ExpressiveScheme } from "../config/config";
 import { ExtendedHass } from "../const/types";
 import { tryPrefetchImageWithFallbacks } from "./utility";
+import { CheckURLResult, getUrlAccessibility } from "./url";
 import localForage from "localforage";
 
 type dynamicSchemeType = new (
@@ -184,8 +185,8 @@ export async function getOrGenerateExpressiveScheme(
   darkMode: boolean,
 ): Promise<{ scheme: DynamicScheme; color: number }> {
   const imgSource = (imageElement as HTMLImageElement | undefined)?.src ?? ``;
-  const isSecure = imgSource.startsWith("https");
-  if (!isSecure) {
+  const isAccessible = getUrlAccessibility(imgSource) === CheckURLResult.ACCESSIBLE;
+  if (!isAccessible) {
     const color = generateDefaultExpressiveSchemeColor();
     const scheme = generateExpressiveSchemeFromColor(
       color,

--- a/src/utils/expressive.ts
+++ b/src/utils/expressive.ts
@@ -113,8 +113,7 @@ export async function generateImageElement(
   fallbacks: string[] = [],
 ): Promise<HTMLImageElement | false> {
   return (await tryPrefetchImageWithFallbacks(img, fallbacks, hass, true)) as
-    | HTMLImageElement
-    | false;
+    HTMLImageElement | false;
 }
 
 export async function generateExpressiveSourceColorFromImage(
@@ -185,7 +184,8 @@ export async function getOrGenerateExpressiveScheme(
   darkMode: boolean,
 ): Promise<{ scheme: DynamicScheme; color: number }> {
   const imgSource = (imageElement as HTMLImageElement | undefined)?.src ?? ``;
-  const isAccessible = getUrlAccessibility(imgSource) === CheckURLResult.ACCESSIBLE;
+  const isAccessible =
+    getUrlAccessibility(imgSource) === CheckURLResult.ACCESSIBLE;
   if (!isAccessible) {
     const color = generateDefaultExpressiveSchemeColor();
     const scheme = generateExpressiveSchemeFromColor(


### PR DESCRIPTION
Color extraction was gated on imgSource.startsWith("https"), which caused it to fall back to the default theme color when HA is accessed locally via HTTP. Now uses getUrlAccessibility() to correctly allow same-origin HTTP images while still blocking inaccessible cross-origin URLs.