### PR TITLE
fix duplicate disconnected callback call

### DIFF
--- a/src/sections/player-queue.ts
+++ b/src/sections/player-queue.ts
@@ -347,7 +347,6 @@ export class QueueCard extends LitElement {
       "section-changed",
       this.onTabSwitch,
     );
-    super.disconnectedCallback();
   }
   public connectedCallback(): void {
     if (this.queueController) {


### PR DESCRIPTION
Fixes `QueueCard.disconnectedCallback()` calling `super.disconnectedCallback()` twice.

The lifecycle callback should only be invoked once, while still unsubscribing queue updates and removing the `section-changed` listener during cleanup.