### PR TITLE
Fix menu button disconnect cleanup

### DIFF
--- a/src/components/menu-button/menu-button.ts
+++ b/src/components/menu-button/menu-button.ts
@@ -195,8 +195,11 @@ export class MassMenuButton extends LitElement {
     }
   }
   disconnectedCallback(): void {
+    super.disconnectedCallback();
+
     if (this.interval) {
       window.clearInterval(this.interval);
+      this.interval = undefined;
     }
   }
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
Ensures `MassMenuButton.disconnectedCallback()` calls the parent Lit lifecycle callback.

The component already clears its interval during disconnect, but it skipped `super.disconnectedCallback()`. This keeps the lifecycle cleanup consistent with the other components and clears the interval reference after cleanup.